### PR TITLE
Fix list-all to get tags for cheat/cheat using git ls-remote

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -24,4 +24,10 @@ list_versions() {
 }
 
 #
-echo "$(list_versions | sort_versions | tr '\n' ' ')"
+readonly GH_REPO="github.com/cheat/cheat"
+list_github_tags() {
+  git ls-remote --tags --refs "https://$GH_REPO" |
+    grep -o 'refs/tags/.*' | cut -d/ -f3- |
+    sed 's/^v//' # NOTE: You might want to adapt this sed to remove non-version strings from tags
+}
+echo "$(list_github_tags | sort_versions | tr '\n' ' ')"


### PR DESCRIPTION
list_versions() failed to get tag names from result of curl to github api for releases, because api returns single-line json. grep/sed are unable to work with this.

Using git ls-remote instead to get the tags.